### PR TITLE
fixed StaffTags

### DIFF
--- a/plugins/staff-tags/src/patches/chat.ts
+++ b/plugins/staff-tags/src/patches/chat.ts
@@ -3,26 +3,27 @@ import { ReactNative, chroma } from "@vendetta/metro/common";
 import { after } from "@vendetta/patcher";
 import getTag, { BUILT_IN_TAGS } from "../lib/getTag";
 
-const getTagProperties = findByName("getTagProperties", false)
-const GuildStore = findByStoreName("GuildStore")
-const ChannelStore = findByStoreName("ChannelStore")
+const getTagProperties = findByName("getTagProperties", false);
+const GuildStore = findByStoreName("GuildStore");
+const ChannelStore = findByStoreName("ChannelStore");
 
-export default () => after("default", getTagProperties, ([{ message }], ret) => {
-    if (!BUILT_IN_TAGS.includes(ret.tagText)) {
-        const channel = ChannelStore.getChannel(message.channel_id)
-        const guild = GuildStore.getGuild(channel?.guild_id)
-
-        const tag = getTag(guild, channel, message.author)
-
-        if (tag) {
-            return {
-                ...ret,
-                tagText: tag.text,
-                tagTextColor: tag.textColor ? ReactNative.processColor(chroma(tag.textColor).hex()) : undefined,
-                tagBackgroundColor: tag.backgroundColor ? ReactNative.processColor(chroma(tag.backgroundColor).hex()) : undefined,
-                tagVerified: tag.verified,
-                tagType: undefined
+export default () => {
+    if (!getTagProperties) return () => {};
+    return after("default", getTagProperties, ([{ message }], ret) => {
+        if (!BUILT_IN_TAGS.includes(ret.tagText)) {
+            const channel = ChannelStore.getChannel(message.channel_id);
+            const guild = GuildStore.getGuild(channel?.guild_id);
+            const tag = getTag(guild, channel, message.author);
+            if (tag) {
+                return {
+                    ...ret,
+                    tagText: tag.text,
+                    tagTextColor: tag.textColor ? ReactNative.processColor(chroma(tag.textColor).hex()) : undefined,
+                    tagBackgroundColor: tag.backgroundColor ? ReactNative.processColor(chroma(tag.backgroundColor).hex()) : undefined,
+                    tagVerified: tag.verified,
+                    tagType: undefined
+                };
             }
         }
-    }
-})
+    });
+};

--- a/plugins/staff-tags/src/patches/name.tsx
+++ b/plugins/staff-tags/src/patches/name.tsx
@@ -5,49 +5,50 @@ import getTag, { BUILT_IN_TAGS } from "../lib/getTag";
 
 const DisplayName = findByName("DisplayName", false);
 const HeaderName = findByName("HeaderName", false);
-
 const TagModule = findByProps("getBotLabel");
-const getBotLabel = TagModule.getBotLabel;
-
+const getBotLabel = TagModule?.getBotLabel;
 const GuildStore = findByStoreName("GuildStore");
 const ChannelStore = findByStoreName("ChannelStore");
 
 export default () => {
-    const patches = []
+    const patches = [];
 
-    patches.push(after("default", HeaderName, ([{ channelId }], ret) => {
-        ret.props.channelId = channelId
-    }))
+    if (HeaderName) {
+        patches.push(after("default", HeaderName, ([{ channelId }], ret) => {
+            ret.props.channelId = channelId;
+        }));
+    }
 
-    patches.push(after("default", DisplayName, ([{ guildId, channelId, user }], ret) => {
-        const tagComponent = findInReactTree(ret, (c) => c.type.Types)
-        if (!tagComponent || !BUILT_IN_TAGS.includes(getBotLabel(tagComponent.props.type))) {
-            const guild = GuildStore.getGuild(guildId)
-            const channel = ChannelStore.getChannel(channelId)
-            const tag = getTag(guild, channel, user)
-
-            if (tag) {
-                if (tagComponent) {
-                    tagComponent.props = {
-                        type: 0,
-                        ...tag
+    if (DisplayName) {
+        patches.push(after("default", DisplayName, ([{ guildId, channelId, user }], ret) => {
+            const tagComponent = findInReactTree(ret, (c) => c.type?.Types);
+            if (!tagComponent || !BUILT_IN_TAGS.includes(getBotLabel?.(tagComponent.props.type))) {
+                const guild = GuildStore.getGuild(guildId);
+                const channel = ChannelStore.getChannel(channelId);
+                const tag = getTag(guild, channel, user);
+                if (tag) {
+                    if (tagComponent) {
+                        tagComponent.props = {
+                            type: 0,
+                            ...tag
+                        };
+                    } else {
+                        const row = findInReactTree(ret, (c) => c.props?.style?.flexDirection === "row");
+                        row?.props.children.push(
+                            <TagModule.default
+                                style={{ marginLeft: 0 }}
+                                type={0}
+                                text={tag.text}
+                                textColor={tag.textColor}
+                                backgroundColor={tag.backgroundColor}
+                                verified={tag.verified}
+                            />
+                        );
                     }
-                } else {
-                    const row = findInReactTree(ret, (c) => c.props.style.flexDirection === "row")
-                    row.props.children.push(
-                        <TagModule.default
-                            style={{ marginLeft: 0 }}
-                            type={0}
-                            text={tag.text}
-                            textColor={tag.textColor}
-                            backgroundColor={tag.backgroundColor}
-                            verified={tag.verified}
-                        />
-                    )
                 }
             }
-        }
-    }))
+        }));
+    }
 
-    return () => patches.forEach((unpatch) => unpatch())
-}
+    return () => patches.forEach(unpatch => unpatch());
+};


### PR DESCRIPTION
Fixed StaffTags plugin not working on Discord 316+ by adding null checks for findByName calls (DisplayName, HeaderName, getTagProperties) that were returning null after Discord updates.